### PR TITLE
Parse cli flag as other parsers do

### DIFF
--- a/src/locator.js
+++ b/src/locator.js
@@ -4,12 +4,22 @@ const ENV_PREFIX = 'gemini_';
 const CLI_PREFIX = '--';
 
 export default function initLocator({options, env, argv}) {
+    argv = argv.reduce(function(argv, arg) {
+        if (!_.includes(arg, '=')) {
+            return argv.concat(arg);
+        }
+        const parts = arg.split('=');
+        const option = parts[0];
+        const value = parts.slice(1).join('=');
+        return argv.concat(option, value);
+    }, []);
+
     function getNested(option, {namePrefix, envPrefix, cliPrefix}) {
         return (subKey) => {
             const envName = envPrefix + _.snakeCase(subKey);
             const cliFlag = cliPrefix + _.kebabCase(subKey);
 
-            const argIndex = argv.indexOf(cliFlag);
+            const argIndex = argv.lastIndexOf(cliFlag);
             const subOption = _.get(option, subKey);
             const newName = `${namePrefix}.${subKey}`;
             return {

--- a/test/locator.test.js
+++ b/test/locator.test.js
@@ -77,6 +77,37 @@ describe('locator', () => {
         assert.propertyVal(childPointer, 'cliOption', 'cli value');
     });
 
+    it('should return cli option set with --option=value syntax', () => {
+        const pointer = locatorWithArgv([
+            '--option=cli value'
+        ]);
+        const childPointer = pointer.nested('option');
+
+        assert.propertyVal(childPointer, 'cliOption', 'cli value');
+    });
+
+    it('should allow to have = sign inside option set with --option=value syntax', () => {
+        const pointer = locatorWithArgv([
+            '--option=cli=value'
+        ]);
+        const childPointer = pointer.nested('option');
+
+        assert.propertyVal(childPointer, 'cliOption', 'cli=value');
+    });
+
+    it('should use last value of an option', () => {
+        const pointer = locatorWithArgv([
+            '--option=first',
+            '--option',
+            'second',
+            '--option',
+            'last'
+        ]);
+        const childPointer = pointer.nested('option');
+
+        assert.propertyVal(childPointer, 'cliOption', 'last');
+    });
+
     it('should look for cli option in kebab-case', () => {
         const pointer = locatorWithArgv([
             '--some-option',


### PR DESCRIPTION
1. Allow --option=value syntax
2. Use last value of an option if it specified multiple time

@j0tunn @scf2k 