### PR TITLE
Default value for map

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ There are 4 types of values:
     - `validate(value, config)` - a function used to validate the option value
     - `map(value, config)` - a function used to transform the option value
 * `section({sectionName1: valueParser1, sectionName2: valueParser2, ...})` - a section of a
-  values with specified key names. Each option will parsed with appropriate parser function. 
+  values with specified key names. Each option will parsed with appropriate parser function.
   Any unknown value passed by user will be treated as an error.
-* `map(valueParser)` - a map with any number of user-specifed keys. Each value is parsed by 
-  `valueParser`.
+* `map(valueParser, defaultValue)` - a map with any number of user-specified keys. Each value is parsed by
+  `valueParser`. If set, `defaultValue` will be used in case of no user-specified data provided.
 * `root(parser)` - creates a root config parsers from specifed parser function. Returns function
   with signature `f({options, env, argv})`.
 

--- a/src/core.js
+++ b/src/core.js
@@ -68,11 +68,15 @@ export function section(properties) {
  * Object with user-specified keys and values,
  * parsed by valueParser.
  */
-export function map(valueParser) {
+export function map(valueParser, defaultValue) {
     return (locator, config) => {
         if (locator.option === undefined) {
-            return {};
+            if (!defaultValue) {
+                return {};
+            }
+            locator = locator.resetOption(defaultValue);
         }
+
         const optionsToParse = Object.keys(locator.option);
         const lazyResult = buildLazyObject(optionsToParse, (key) => {
             return () => valueParser(locator.nested(key), config);

--- a/src/locator.js
+++ b/src/locator.js
@@ -22,30 +22,47 @@ export default function initLocator({options, env, argv}) {
             const argIndex = argv.lastIndexOf(cliFlag);
             const subOption = _.get(option, subKey);
             const newName = `${namePrefix}.${subKey}`;
-            return {
-                name: newName,
-                option: subOption,
-                envVar: env[envName],
-                cliOption: argIndex > -1 ? argv[argIndex + 1] : undefined,
-                nested: getNested(subOption, {
+
+            return mkLocator(
+                {
+                    name: newName,
+                    option: subOption,
+                    envVar: env[envName],
+                    cliOption: argIndex > -1 ? argv[argIndex + 1] : undefined
+                },
+                {
                     namePrefix: newName,
                     envPrefix: `${envName}_`,
                     cliPrefix: `${cliFlag}-`
-                })
-            };
+                }
+            );
         };
     }
 
-    return {
-        name: 'root',
-        option: options,
-        envVar: undefined,
-        cliOption: undefined,
-        nested: getNested(options, {
+    function mkLocator(base, prefixes) {
+        return _.extend(base, {
+            nested: getNested(base.option, prefixes),
+            resetOption: function(newOptions) {
+                return _.extend({}, base, {
+                    option: newOptions,
+                    nested: getNested(newOptions, prefixes)
+                });
+            }
+        });
+    }
+
+    return mkLocator(
+        {
+            name: 'root',
+            option: options,
+            envVar: undefined,
+            cliOption: undefined
+        },
+        {
             namePrefix: '',
             envPrefix: ENV_PREFIX,
             cliPrefix: CLI_PREFIX
-        })
-    };
+        }
+    );
 }
 

--- a/test/locator.test.js
+++ b/test/locator.test.js
@@ -151,4 +151,27 @@ describe('locator', () => {
         assert.propertyVal(childPointer, 'envVar', 'env value');
         assert.propertyVal(childPointer, 'cliOption', 'cli value');
     });
+
+    it('should reset option', () => {
+        const pointer = locator({
+            env: {
+                'gemini_first_second': 'env value'
+            },
+            argv: [
+                '--first-second', 'cli value'
+            ]
+        });
+
+        const newPointer = pointer.resetOption({
+            first: {
+                second: 'value'
+            }
+        });
+
+        const childPointer = newPointer.nested('first').nested('second');
+
+        assert.propertyVal(childPointer, 'option', 'value');
+        assert.propertyVal(childPointer, 'envVar', 'env value');
+        assert.propertyVal(childPointer, 'cliOption', 'cli value');
+    });
 });


### PR DESCRIPTION
- Locator extended with `resetOption` function, which can be used to replace whole options tree down from current locator
- In case of no user key/val pairs provided map uses defaultValue to reset locator option