### PR TITLE
fix: fix incorrect behavior when namePrefix is empty

### DIFF
--- a/lib/locator.js
+++ b/lib/locator.js
@@ -18,7 +18,7 @@ module.exports = function({options, env, argv, envPrefix = '', cliPrefix = '--'}
 
             const argIndex = argv.lastIndexOf(cliFlag);
             const subOption = _.get(option, subKey);
-            const newName = `${namePrefix}.${subKey}`;
+            const newName = namePrefix ? `${namePrefix}.${subKey}` : subKey;
 
             return mkLocator(
                 {

--- a/test/locator.js
+++ b/test/locator.js
@@ -37,7 +37,7 @@ describe('locator', () => {
     it('should return nested name after nest call', () => {
         const pointer = locatorWithOptions({});
         const childPointer = pointer.nested('key');
-        assert.propertyVal(childPointer, 'name', '.key');
+        assert.propertyVal(childPointer, 'name', 'key');
     });
 
     it('should return empty parent for root children', () => {
@@ -50,7 +50,7 @@ describe('locator', () => {
         const pointer = locatorWithOptions({someKey: 'someVal'});
         const childPointer = pointer.nested('child');
         const subChildPointer = childPointer.nested('subChild');
-        assert.propertyVal(subChildPointer, 'parent', '.child');
+        assert.propertyVal(subChildPointer, 'parent', 'child');
     });
 
     it('should return env var value after nested call', () => {


### PR DESCRIPTION
When `namePrefix` is empty the `newName` is formed with a dot at the beginning. Later, `newName` is used to retrieve values from config and this dot causes such retrievals to result in `undefined`.