### PR TITLE
fix(locator): fix argv parsing

### DIFF
--- a/lib/locator.js
+++ b/lib/locator.js
@@ -1,22 +1,28 @@
 const _ = require('lodash');
 
-module.exports = function({options, env, argv, envPrefix = '', cliPrefix = '--'}) {
-    argv = argv.reduce(function(argv, arg) {
-        if (!_.includes(arg, '=')) {
+function parseArgv(argv, cliPrefix) {
+    return argv.reduce(function(argv, arg) {
+        if (!arg.startsWith(cliPrefix) || !_.includes(arg, '=')) {
             return argv.concat(arg);
         }
+
         const parts = arg.split('=');
         const option = parts[0];
         const value = parts.slice(1).join('=');
+
         return argv.concat(option, value);
     }, []);
+}
+
+module.exports = function({options, env, argv, envPrefix = '', cliPrefix = '--'}) {
+    const parsedArgv = parseArgv(argv, cliPrefix);
 
     function getNested(option, {namePrefix, envPrefix, cliPrefix}) {
         return (subKey) => {
             const envName = envPrefix + _.snakeCase(subKey);
             const cliFlag = cliPrefix + _.kebabCase(subKey);
 
-            const argIndex = argv.lastIndexOf(cliFlag);
+            const argIndex = parsedArgv.lastIndexOf(cliFlag);
             const subOption = _.get(option, subKey);
             const newName = namePrefix ? `${namePrefix}.${subKey}` : subKey;
 
@@ -26,7 +32,7 @@ module.exports = function({options, env, argv, envPrefix = '', cliPrefix = '--'}
                     parent: namePrefix,
                     option: subOption,
                     envVar: env[envName],
-                    cliOption: argIndex > -1 ? argv[argIndex + 1] : undefined
+                    cliOption: argIndex > -1 ? parsedArgv[argIndex + 1] : undefined
                 },
                 {
                     namePrefix: newName,
@@ -64,4 +70,3 @@ module.exports = function({options, env, argv, envPrefix = '', cliPrefix = '--'}
         }
     );
 };
-

--- a/test/locator.js
+++ b/test/locator.js
@@ -99,7 +99,7 @@ describe('locator', () => {
         assert.propertyVal(childPointer, 'cliOption', 'cli value');
     });
 
-    it('should return cli option set with --option=value syntax', () => {
+    it('should return cli option set with --option="cli value"', () => {
         const pointer = locatorWithArgv([
             '--option=cli value'
         ]);
@@ -108,9 +108,19 @@ describe('locator', () => {
         assert.propertyVal(childPointer, 'cliOption', 'cli value');
     });
 
-    it('should allow to have = sign inside option set with --option=value syntax', () => {
+    it('should allow to have = sign inside option set with --option="cli=value"', () => {
         const pointer = locatorWithArgv([
             '--option=cli=value'
+        ]);
+        const childPointer = pointer.nested('option');
+
+        assert.propertyVal(childPointer, 'cliOption', 'cli=value');
+    });
+
+    it('should allow to have = sign inside option set with --option "cli=value"', () => {
+        const pointer = locatorWithArgv([
+            '--option',
+            'cli=value'
         ]);
         const childPointer = pointer.nested('option');
 


### PR DESCRIPTION
#### Проблема:
Парсер неверно обрабатывает аргумент cli, если его название и значение указаны через пробел и значение содержит знак равно, например: `--some-arg some-value=10`. В этом случае аргументы будут распаршены как: `['--some-arg', 'some-value', '10']`, а должно быть так: `['--some-arg', 'some-value=10']`.

Это происходит, так как есть логика обработки значений указанных через `=`. То есть аргумент `--some-arg=some-value=10` будет передан в `process.argv` как `['--some-arg=some-value=10']`. Поэтому мы проходимся по всем полученым аргументам и разбиваем их по первому знаку `=`. Однако, если передать значения через пробел `--some-arg some-value=10`, то в `process.argv` будет находиться `['--some-arg', 'some-value=10']` и текущая логика попытается разделить значение по знаку `=`.

#### Что сделано:
Чтобы этого избежать, нужно разделять переданные аргументы на ключ и значение. Для определения того, обрабатываем мы ключ или значение у нас есть информация о префиксе аргумента (по умолчанию на верхнем уровне это `--`).

Так как парсер поддерживает лишь парное переопределение параметров через аргументы `cli` (без булевых `--some-arg`), то достаточно предусмотреть лишь 2 случая:
* `--some-arg=some-value=10`
* `--some-arg some-value=10`

